### PR TITLE
Added new option for bypassing requests with GET query parameters

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -1,6 +1,12 @@
-var memCache    = require('memory-cache');
 var inflection  = require('inflection');
 var _           = require('lodash');
+var redis       = require('redis'),
+    client      = redis.createClient();
+
+client.on('error', function(err) {
+  console.log('Error '+error);
+});
+
 
 var t           = {
   seconds:      1000,
@@ -16,7 +22,7 @@ function ApiCache() {
   var globalOptions = {
     debug:            false,
     defaultDuration:  3600000,
-    enabled:          true,
+    enabled:          true
   };
 
   var index = null;
@@ -33,7 +39,7 @@ function ApiCache() {
         if (globalOptions.debug) {
           console.log('[api-cache]: clearing key: ', key);
         }
-        memCache.del(key);
+        client.del(key);
         index.all = _.without(index.all, key);
       });
 
@@ -42,7 +48,7 @@ function ApiCache() {
       if (globalOptions.debug) {
         console.log('[api-cache]: clearing key: ', target);
       }
-      memCache.del(target);
+      client.del(target);
       index.all = _.without(index.all, target);
       _.each(index.groups, function(group, groupName) {
         index.groups[groupName] = _.without(group, target);
@@ -54,7 +60,7 @@ function ApiCache() {
       if (globalOptions.debug) {
         console.log('[api-cache]: clearing entire index');
       }
-      memCache.clear();
+      client.keys('*');
       this.resetIndex();
     }
 
@@ -84,10 +90,9 @@ function ApiCache() {
     if (typeof duration !== 'number' || duration === 0) {
       duration = globalOptions.defaultDuration ;
     }
-
     return function cache(req, res, next) {
-      var cached;
 
+      var cached;
       if (!globalOptions.enabled || req.headers['x-apicache-bypass'] || (_.isFunction(middlewareToggle) && !middlewareToggle(req, res))) {
         if (globalOptions.debug && req.headers['x-apicache-bypass']) {
           console.log('[api-cache]: bypass detected, skipping cache.');
@@ -95,59 +100,62 @@ function ApiCache() {
         return next();
       }
 
-      if (cached = memCache.get(req.url)) {
-        if (globalOptions.debug) {
-          console.log('[api-cache]: returning cached version of "' + req.url + '"');
-        }
-
-        res.statusCode = cached.status;
-        res.set(cached.headers);
-
-        return res.send(cached.body);
-      } else {
-        if (globalOptions.debug) {
-          console.log('[api-cache]: path "' + req.url + '" not found in cache');
-        }
-
-        res.realSend = res.send;
-
-        res.send = function(a, b) {
-          var responseObj = {
-            headers: {
-              'Content-Type': 'application/json; charset=utf-8'
-            }
-          };
-
-          responseObj.status  = !_.isUndefined(b) ? a : (_.isNumber(a) ? a : res.statusCode);
-          responseObj.body    = !_.isUndefined(b) ? b : (!_.isNumber(a) ? a : null);
-
-          // last bypass attempt
-          if (!memCache.get(req.url) && !req.headers['x-apicache-bypass']) {
-            if (globalOptions.debug) {
-              if (req.apicacheGroup) {
-                console.log('[api-cache]: group detected: ' + req.apicacheGroup);
-                index.groups[req.apicacheGroup] = index.groups[req.apicacheGroup] || [];
-                index.groups[req.apicacheGroup].push(req.url);
-              }
-
-              index.all.push(req.url);
-              console.log('[api-cache]: adding cache entry for "' + req.url + '" @ ' + duration + ' milliseconds');
-            }
-
-            _.each(['Cache-Control', 'Expires'], function(h) {
-              var header = res.get(h);
-              if (!_.isUndefined(header)) {
-                responseObj.headers[h] = header;
-              }
-            });
-
-            memCache.put(req.url, responseObj, duration);
+      client.get(req.url, function(err, reply) {
+        if (reply) {
+          if (globalOptions.debug) {
+            console.log('[api-cache]: returning cached version of "' + req.url + '"');
           }
 
-          return res.realSend(responseObj.body);
-        };
-        next();
-      }
+          var r = JSON.parse(reply);
+          res.statusCode = r.status;
+          res.set(r.headers);
+          res.send(r.body);
+        } else {
+
+          if (globalOptions.debug) {
+            console.log('[api-cache]: path "' + req.url + '" not found in cache');
+          }
+
+          res.realSend = res.send;
+
+          res.send = function(a, b) {
+            var responseObj = {
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+              }
+            };
+
+            responseObj.status  = !_.isUndefined(b) ? a : (_.isNumber(a) ? a : res.statusCode);
+            responseObj.body    = !_.isUndefined(b) ? b : (!_.isNumber(a) ? a : null);
+
+            // last bypass attempt
+            if (!reply && !req.headers['x-apicache-bypass']) {
+              if (globalOptions.debug) {
+                if (req.apicacheGroup) {
+                  console.log('[api-cache]: group detected: ' + req.apicacheGroup);
+                  index.groups[req.apicacheGroup] = index.groups[req.apicacheGroup] || [];
+                  index.groups[req.apicacheGroup].push(req.url);
+                }
+
+                index.all.push(req.url);
+                console.log('[api-cache]: adding cache entry for "' + req.url + '" @ ' + duration + ' milliseconds');
+              }
+
+              _.each(['Cache-Control', 'Expires'], function(h) {
+                var header = res.get(h);
+                if (!_.isUndefined(header)) {
+                  responseObj.headers[h] = header;
+                }
+              });
+              client.setex(req.url, Math.round(duration / 1000), JSON.stringify(responseObj));
+            }
+
+            return res.realSend(responseObj.body);
+          };
+          next();
+        }
+      });
+
     };
   };
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "memory-cache": "0.0.5",
     "lodash": "~1.3.1",
-    "inflection": "~1.2.6"
+    "inflection": "~1.2.6",
+    "redis": "~0.10.1"
   }
 }


### PR DESCRIPTION
@kwhitley,

I found myself using this bypass in an edge case where a route is largely controlled by query parameters. For instance, I have a route that processes up to 10 different filters (including: limit, offset, state, search, option1, option2, etc.). However, since each user for this route will have unique specific needs, it makes little sense to cache requests with these specific query parameters. However, having the default route cached can make a significant difference.

So, I implemented a `bypassQuery` option for these needs. Let me know what you think!
