### PR TITLE
Bypass caching error pages

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -122,7 +122,7 @@ function ApiCache() {
           responseObj.body    = !_.isUndefined(b) ? b : (!_.isNumber(a) ? a : null);
 
           // last bypass attempt
-          if (!memCache.get(req.url) && !req.headers['x-apicache-bypass']) {
+          if (!memCache.get(req.url) && !req.headers['x-apicache-bypass'] && responseObj.status < 400) {
             if (globalOptions.debug) {
               if (req.apicacheGroup) {
                 console.log('[api-cache]: group detected: ' + req.apicacheGroup);


### PR DESCRIPTION
Fixing #4 dirty branch:

Anything 400 and over is basically an error and will mistakenly get cached (when it shouldn't). 

I saw you mention the bypass flags in #3; however, isn't this something that should be a default behavior?

PS: Tested and working.
