### PR TITLE
Added the option to append to URL key anything from the req object

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm install apicache
   debug:            false|true,   // if true, enables console output
   defaultDuration:  3600000,      // should be a number (in ms), defaults to 1 hour
   enabled:          true|false,   // if false, turns off caching globally (useful on dev)
+  appendKey:        [],           // if you want the key (which is the URL) to be appended by something in the req object, put req properties here that point to what you want appended. I.E. req.session.id would be ['session', 'id']
 }
 ```
 

--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -17,6 +17,7 @@ function ApiCache() {
     debug:            false,
     defaultDuration:  3600000,
     enabled:          true,
+    appendKey:        [],
   };
 
   var index = null;
@@ -95,9 +96,20 @@ function ApiCache() {
         return next();
       }
 
-      if (cached = memCache.get(req.url)) {
+      var key = req.url;
+
+      if (globalOptions.appendKey.length > 0) {
+        var appendKey = req;
+
+        for (var i = 0; i < globalOptions.appendKey.length; i++) {
+          appendKey = appendKey[globalOptions.appendKey[i]];
+        }
+        key += '/appendKey=' + appendKey;
+      }
+
+      if (cached = memCache.get(key)) {
         if (globalOptions.debug) {
-          console.log('[api-cache]: returning cached version of "' + req.url + '"');
+          console.log('[api-cache]: returning cached version of "' + key + '"');
         }
 
         res.statusCode = cached.status;
@@ -106,7 +118,7 @@ function ApiCache() {
         return res.send(cached.body);
       } else {
         if (globalOptions.debug) {
-          console.log('[api-cache]: path "' + req.url + '" not found in cache');
+          console.log('[api-cache]: path "' + key + '" not found in cache');
         }
 
         res.realSend = res.send;
@@ -122,16 +134,16 @@ function ApiCache() {
           responseObj.body    = !_.isUndefined(b) ? b : (!_.isNumber(a) ? a : null);
 
           // last bypass attempt
-          if (!memCache.get(req.url) && !req.headers['x-apicache-bypass']) {
+          if (!memCache.get(key) && !req.headers['x-apicache-bypass']) {
             if (globalOptions.debug) {
               if (req.apicacheGroup) {
                 console.log('[api-cache]: group detected: ' + req.apicacheGroup);
                 index.groups[req.apicacheGroup] = index.groups[req.apicacheGroup] || [];
-                index.groups[req.apicacheGroup].push(req.url);
+                index.groups[req.apicacheGroup].push(key);
               }
 
-              index.all.push(req.url);
-              console.log('[api-cache]: adding cache entry for "' + req.url + '" @ ' + duration + ' milliseconds');
+              index.all.push(key);
+              console.log('[api-cache]: adding cache entry for "' + key + '" @ ' + duration + ' milliseconds');
             }
 
             _.each(['Cache-Control', 'Expires'], function(h) {
@@ -141,7 +153,7 @@ function ApiCache() {
               }
             });
 
-            memCache.put(req.url, responseObj, duration);
+            memCache.put(key, responseObj, duration);
           }
 
           return res.realSend(responseObj.body);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apicache",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "An ultra-simplified API/JSON response caching middleware for Express/Node using plain-english durations.",
   "main": "./lib/apicache.js",
   "repository": {


### PR DESCRIPTION
My team could not cache strictly from the URL because different authenticated users hit the same exact endpoints, just under different sessions. Without being able to append to the URL key, one user might get another user's cached data. This allows for a simple (and optional) way to append to the URL key anything from the request object in order to make it as unique as need be on a user by user basis