### PR TITLE
Add bypassCache callback to allow for not returning cached content

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -70,7 +70,7 @@ function ApiCache() {
     }
   };
 
-  this.middleware = function cache(duration, middlewareToggle) {
+  this.middleware = function cache(duration, middlewareToggle, bypassCache) {
     if (typeof duration === 'string') {
       var split = duration.match(/^(\d+)\s(\w+)$/);
 
@@ -108,6 +108,10 @@ function ApiCache() {
       }
 
       if (cached = memCache.get(key)) {
+        if (_.isFunction(bypassCache) && bypassCache(req, res)) {
+          return next();
+        }
+
         if (globalOptions.debug) {
           console.log('[api-cache]: returning cached version of "' + key + '"');
         }


### PR DESCRIPTION
This is a potential solution for #3 as well as meeting my needs.  In my case I wanted only certain browsers to receive the cached content (PhantomJS for screenshots), and so needed away to allow for requests to be set in the cache but only used if they matched the condition.  It would allow #3 to be solved by never returning the cached version based on status code.  I'm not a huge fan of another argument to the `cache` function but the only other solution I could see is by having variables that can be toggled by middleware (e.g. a middleware higher up the stack could toggle a `res.apicache_disable` variable).  I'm open to that approach, but it would be more of a change from the current way of doing things.