### PR TITLE
Add genCacheKey option to allow for cache key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ npm install apicache
 
 ```js
 {
-  debug:            false|true,   // if true, enables console output
-  defaultDuration:  3600000,      // should be a number (in ms), defaults to 1 hour
-  enabled:          true|false,   // if false, turns off caching globally (useful on dev)
-  appendKey:        [],           // if you want the key (which is the URL) to be appended by something in the req object, put req properties here that point to what you want appended. I.E. req.session.id would be ['session', 'id']
+  debug:            false|true,    // if true, enables console output
+  defaultDuration:  3600000,       // should be a number (in ms), defaults to 1 hour
+  enabled:          true|false,    // if false, turns off caching globally (useful on dev)
+  appendKey:        [],            // if you want the key (which is the URL) to be appended by something in the req object, put req properties here that point to what you want appended. I.E. req.session.id would be ['session', 'id']
+  genCacheKey:      req => req.url // allows for fine-grained control over the cache key. I.E req.url + req.header('user-agent')
 }
 ```
 

--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -18,6 +18,7 @@ function ApiCache() {
     defaultDuration:  3600000,
     enabled:          true,
     appendKey:        [],
+    genCacheKey:      function (req) { return req.url; }
   };
 
   var index = null;
@@ -96,7 +97,7 @@ function ApiCache() {
         return next();
       }
 
-      var key = req.url;
+      var key = globalOptions.genCacheKey(req);
 
       if (globalOptions.appendKey.length > 0) {
         var appendKey = req;


### PR DESCRIPTION
This allows for fine-grained control over the cache key, such as basing the cache key off of the user-agent string.  This obviously overlaps in functionality with `appendKey` but is more flexible (in my case I actually wanted to change the URL).  
