### PR TITLE
Use the full URL for Express 4.x

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -95,8 +95,8 @@ function ApiCache() {
         }
         return next();
       }
-
-      var key = req.url;
+      // In Express 4.x the url is ambigious based on where a router is mounted.  originalUrl will give the full Url
+      var key = req.originalUrl || req.url;
 
       if (globalOptions.appendKey.length > 0) {
         var appendKey = req;


### PR DESCRIPTION
In Express 4.x the url is ambigious based on where a router is mounted.  originalUrl will give the full Url