### PR TITLE
Added header option to force a fetch but not bypassing the store.

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -112,7 +112,7 @@ function ApiCache() {
       }
       // In Express 4.x the url is ambigious based on where a router is mounted.  originalUrl will give the full Url
       var key = req.originalUrl || req.url;
-      
+
       // Remove querystring from key if jsonp option is enabled
       if (globalOptions.jsonp) {
         key = url.parse(key).pathname;
@@ -131,7 +131,7 @@ function ApiCache() {
         cached = memCache.get(key);
       }
 
-      if (cached || globalOptions.redisClient) {
+      if ((cached || globalOptions.redisClient) && !req.headers['x-apicache-force-fetch']) {
 
         if (!globalOptions.redisClient) {
 
@@ -187,9 +187,9 @@ function ApiCache() {
         }
 
         res.realSend = (globalOptions.jsonp) ? res.jsonp : res.send;
-        
+
         var methodName = (globalOptions.jsonp) ? "jsonp" : "send";
-        
+
         res[methodName] = function(a, b) {
           var responseObj = {
             headers: {
@@ -211,7 +211,7 @@ function ApiCache() {
             }
 
             index.all.push(key);
-            
+
             if (globalOptions.debug) {
               console.log('[api-cache]: adding cache entry for "' + key + '" @ ' + duration + ' milliseconds');
             }

--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -107,7 +107,7 @@ function ApiCache() {
         key += '/appendKey=' + appendKey;
       }
 
-      if (cached = memCache.get(key)) {
+      if ((cached = memCache.get(key)) && !req.headers['x-apicache-force-fetch']) {
         if (globalOptions.debug) {
           console.log('[api-cache]: returning cached version of "' + key + '"');
         }


### PR DESCRIPTION
Implemented a way to force the fetch, bypassing the cache, but storing the result after that.

Useful for pre-fetches to maintain the api with low latency.