### PR TITLE
Fixed issue with Cache groups in debug mode

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -135,14 +135,17 @@ function ApiCache() {
 
           // last bypass attempt
           if (!memCache.get(key) && !req.headers['x-apicache-bypass']) {
-            if (globalOptions.debug) {
-              if (req.apicacheGroup) {
+            if (req.apicacheGroup) {
+              if (globalOptions.debug) {
                 console.log('[api-cache]: group detected: ' + req.apicacheGroup);
-                index.groups[req.apicacheGroup] = index.groups[req.apicacheGroup] || [];
-                index.groups[req.apicacheGroup].push(key);
               }
+              index.groups[req.apicacheGroup] = index.groups[req.apicacheGroup] || [];
+              index.groups[req.apicacheGroup].push(key);
+            }
 
-              index.all.push(key);
+            index.all.push(key);
+            
+            if (globalOptions.debug) {
               console.log('[api-cache]: adding cache entry for "' + key + '" @ ' + duration + ' milliseconds');
             }
 


### PR DESCRIPTION
Fixed nesting for `if (globalOptions.debug)` statements https://github.com/kwhitley/apicache/issues/8
All cache functionality should work fine without debug mode now.