### PR TITLE
Cache 'Content-Encoding' header

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -216,7 +216,7 @@ function ApiCache() {
               console.log('[api-cache]: adding cache entry for "' + key + '" @ ' + duration + ' milliseconds');
             }
 
-            _.each(['Cache-Control', 'Expires'], function(h) {
+            _.each(['Cache-Control', 'Expires', 'Content-Encoding'], function(h) {
               var header = res.get(h);
               if (!_.isUndefined(header)) {
                 responseObj.headers[h] = header;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apicache",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "An ultra-simplified API/JSON response caching middleware for Express/Node using plain-english durations.",
   "main": "./lib/apicache.js",
   "repository": {


### PR DESCRIPTION
Apicache is failing to cache the 'content-encoding' header. As a result, when you retrieve something from cache that is gzipped, the browser (or whoever is viewing the document from cache) does not realize that the content should be decompressed before display.

This change fixes this problem by adding 'Content-Encoding' to the explicit list of headers that should be cached, alongside 'Cache-Control' and 'Expires'.