### PR TITLE
Fix headers issue when using redis

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -167,7 +167,7 @@ function ApiCache() {
 
                 var redis_responseObj = JSON.parse(obj.responseObj);
                 res.statusCode = redis_responseObj.status;
-                res.set(JSON.stringify(redis_responseObj.headers));
+                res.set(redis_responseObj.headers);
                 return res.send(redis_responseObj.body);
               }else{
                 buildCacheObj();


### PR DESCRIPTION
res.set(JSON.stringify(redis_responseObj.headers));

Stringify here is causing the issue, I removed it.
This works fine.
res.set(redis_responseObj.headers);