### PR TITLE
Add on miss and on hit events

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -20,7 +20,9 @@ function ApiCache() {
     enabled:            true,
     appendKey:          [],
     jsonp:              false,
-    redisClient:        false
+    redisClient:        false,
+    onHitEvent:         function(){ return undefined; },
+    onMissEvent:        function(){ return undefined; }
   };
 
   var index = null;
@@ -143,9 +145,10 @@ function ApiCache() {
           res.set(cached.headers);
 
           if(globalOptions.jsonp) {
-            return res.jsonp(cached.body);
+            res.jsonp(cached.body);
+          }else{
+            res.send(cached.body);
           }
-          return res.send(cached.body);
 
         } else {
 
@@ -168,7 +171,7 @@ function ApiCache() {
                 var redis_responseObj = JSON.parse(obj.responseObj);
                 res.statusCode = redis_responseObj.status;
                 res.set(JSON.stringify(redis_responseObj.headers));
-                return res.send(redis_responseObj.body);
+                res.send(redis_responseObj.body);
               }else{
                 buildCacheObj();
               }
@@ -176,9 +179,12 @@ function ApiCache() {
           });
 
         }
-
+        // call on hit event
+        globalOptions.onHitEvent();
       } else {
         buildCacheObj();
+        // call miss
+        globalOptions.onMissEvent();
       }
 
       function buildCacheObj() {


### PR DESCRIPTION
I made the code call an optional event on miss/hit at the end. I had to remove a few 'returns' and refactored an if-statement.

I personally use these events like this:

```
// cache
var apicache = require('apicache').options(
    C.cacheConfig(client, 
    function(reporter){
        reporter.event('Hit', 'Cache').send();
    }.bind(null, C.reporter)
)).middleware;
```

I believe this will be helpful.
