### PR TITLE
Create variable to avoid reference error.

### DIFF
--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -108,7 +108,7 @@ function ApiCache() {
   };
 
   this.middleware = function cache(strDuration, middlewareToggle) {
-    duration = instance.getDuration(strDuration);
+    var duration = instance.getDuration(strDuration);
 
     return function cache(req, res, next) {
       var cached;


### PR DESCRIPTION
The error caused is this:
I've been getting this error in production (node 5.11.1) whenever the server is started. This change fixes that.

```
ReferenceError: duration is not defined
    at cache ([...]/node_modules/apicache/lib/apicache.js:111:14)
```