### PR TITLE
Feature/remove deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,4 +187,5 @@ Special thanks to all those that use this library and report issues, but especia
 
 - @Amhri, @Webcascade, @conmarap, @cjfurelid
 
-
+### Changelog
+- v0.4.0 - dropped lodash and memory-cache external dependencies, and bumped node version requirements to 4.0.0+ to allow Object.assign native support

--- a/lib/apicache.js
+++ b/lib/apicache.js
@@ -1,8 +1,7 @@
 var message     = require('debug')('apicache');
 var url         = require('url');
-var _           = require('lodash');
 var MemoryCache = require('./memory-cache');
-var pjson       = require('../package.json');
+var pkg         = require('../package.json');
 
 var t           = {
   ms:           1,
@@ -16,6 +15,14 @@ var t           = {
 };
 
 var instances = [];
+
+var matches = function(a) {
+  return function(b) { return a === b }
+}
+
+var doesntMatch = function(a) {
+  return function(b) { return !matches(a)(b) }
+}
 
 function ApiCache() {
   var memCache = new MemoryCache;
@@ -58,13 +65,14 @@ function ApiCache() {
   }
 
   this.clear = function(target) {
+    debug('cache.clear called with target', target)
+
     var group = index.groups[target];
 
     if (group) {
-      console.log('clearing group', group)
       debug('clearing group "' + target + '"');
 
-      _.each(group, function(key) {
+      group.forEach(function(key) {
         debug('clearing cached entry for "' + key + '"');
 
         if (!globalOptions.redisClient) {
@@ -72,7 +80,7 @@ function ApiCache() {
         } else {
           globalOptions.redisClient.del(key);
         }
-        index.all = _.without(index.all, key);
+        index.all = index.all.filter(doesntMatch(key));
       });
 
       delete index.groups[target];
@@ -84,9 +92,13 @@ function ApiCache() {
       } else {
         globalOptions.redisClient.del(target);
       }
-      index.all = _.without(index.all, target);
-      _.each(index.groups, function(group, groupName) {
-        index.groups[groupName] = _.without(group, target);
+
+      index.all = index.all.filter(doesntMatch(target))
+
+      Object.keys(index.groups).forEach(function(groupName) {
+        var group = index.groupss[groupName]
+
+        index.groups[groupName] = index.groups[groupName].filter(doesntMatch(group));
         if (!index.groups[groupName].length) {
           delete index.groups[groupName];
         }
@@ -135,8 +147,6 @@ function ApiCache() {
 
   this.middleware = function cache(strDuration, middlewareToggle) {
     var duration = instance.getDuration(strDuration);
-
-
 
     return function cache(req, res, next) {
       var cached;
@@ -234,8 +244,8 @@ function ApiCache() {
             }
           };
 
-          responseObj.status  = !_.isUndefined(b) ? a : (_.isNumber(a) ? a : res.statusCode);
-          responseObj.body    = !_.isUndefined(b) ? b : (!_.isNumber(a) ? a : null);
+          responseObj.status  = b !== undefined ? a : (typeof a === 'number' ? a : res.statusCode);
+          responseObj.body    = b !== undefined ? b : (typeof a !== 'number' ? a : null);
 
           // last bypass attempt
           if (shouldCacheResponse(responseObj) && !memCache.get(key) && !req.headers['x-apicache-bypass']) {
@@ -250,14 +260,16 @@ function ApiCache() {
 
             debug('adding cache entry for "' + key + '" @ ' + strDuration);
 
-            _.each(['Cache-Control', 'Expires', 'Content-Encoding'], function(h) {
+            var useHeaders = ['Cache-Control', 'Expires', 'Content-Encoding'];
+
+            useHeaders.forEach(function(h) {
               var header = res.get(h);
-              if (!_.isUndefined(header)) {
+              if (header !== undefined) {
                 responseObj.headers[h] = header;
               }
             });
 
-            responseObj.headers['apicache-version'] = pjson.version;
+            responseObj.headers['apicache-version'] = pkg.version;
 
             if (!globalOptions.redisClient) {
               responseObj.headers['apicache-store'] = 'memory';
@@ -281,7 +293,7 @@ function ApiCache() {
 
   this.options = function(options) {
     if (options) {
-      _.extend(globalOptions, options);
+      Object.assign(globalOptions, options);
 
       return this;
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apicache",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "scripts": {
     "test": "mocha $(find test -name '*.test.js') --recursive",
     "dev": "npm run test -- --watch",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepublish": "npm run test"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0.0"
   },
   "description": "An ultra-simplified API/JSON response caching middleware for Express/Node using plain-english durations.",
   "main": "./lib/apicache.js",
@@ -36,7 +36,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "express": "^4.14.0",
-    "fake-api-server": "^0.4.0",
     "grunt": "latest",
     "grunt-contrib-jshint": "latest",
     "grunt-contrib-nodeunit": "latest",
@@ -46,7 +45,6 @@
     "supertest": "^2.0.0"
   },
   "dependencies": {
-    "debug": "^2.2.0",
-    "lodash": "^4.15.0"
+    "debug": "^2.2.0"
   }
 }

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -138,6 +138,19 @@ describe('.clear(key?) {SETTER}', function() {
       })
   })
 
+  it('works when called with specific endpoint (non-group) key', function(done) {
+    var mockAPI = require('./mock_api')('10 seconds')
+
+    request(mockAPI)
+      .get('/api/movies')
+      .end(function(err, res) {
+        expect(mockAPI.requestsProcessed).to.equal(1)
+        expect(mockAPI.apicache.getIndex().all.length).to.equal(1)
+        expect(mockAPI.apicache.clear('/api/movies').all.length).to.equal(0)
+        done()
+      })
+  })
+
   it('works when called with no key', function(done) {
     var mockAPI = require('./mock_api')('10 seconds')
 


### PR DESCRIPTION
Removes lodash and memory-cache direct dependencies, removes unneeded dev dep, and now requires node version 4.0.0+ (previously allowed 0.12.0+)