### PR TITLE
fix missing headers for restify

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "chai": "^3.5.0",
     "compression": "^1.6.2",
     "express": "^4.14.0",
+    "fakeredis": "^1.0.3",
     "mocha": "^3.0.2",
     "redis": "^2.6.3",
+    "restify": "^4.3.0",
     "supertest": "^2.0.0"
   },
   "dependencies": {}

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -157,7 +157,8 @@ function ApiCache() {
 
 
   function sendCachedResponse(response, cacheObject) {
-    Object.assign(response._headers || {}, cacheObject.headers || {}, {
+    response._headers = response._headers || {}
+    Object.assign(response._headers, cacheObject.headers || {}, {
       'apicache-store': globalOptions.redisClient ? 'redis' : 'memory',
       'apicache-version': pkg.version
     })

--- a/test/mock_api_restify.js
+++ b/test/mock_api_restify.js
@@ -1,0 +1,91 @@
+var movies = [{
+  title: 'The Prestige',
+  director: 'Christopher Nolan',
+},{
+  title: 'Schindler\'s List',
+  director: 'Steven Spielberg'
+}]
+
+var instances = []
+
+function MockAPI(expiration, options) {
+  // console.log('creating MockAPI with expiration in ' + expiration + ' with ApiCache config', options)
+  var restify = require('restify')
+  var apicache = require('../src/apicache').newInstance(options)
+
+  var app = restify.createServer();
+
+  instances.push(this)
+
+  this.apicache = apicache
+  this.id = instances.length
+  this.app = app
+
+  // console.log('instantiating MockAPI:' + this.id + ' with expiration of ' + expiration)
+  // console.log('this.id vs this.apicache.id', this.id, this.apicache.id)
+  instances.forEach((instance, id) => {
+    // console.log('instance id:apicache.id', instance.id, instance.apicache.id)
+    if (instance.id !== this.id && this.apicache === instance.apicache) {
+      console.log('WARNING: SHARED APICACHE INSTANCE', id, this.id, this.apicache.id, instance.apicache.id)
+    }
+    if (instance.id !== this.id && this.app === instance.app) {
+      console.log('WARNING: SHARED EXPRESS INSTANCE', id, this.id)
+    }
+  })
+
+  app.use(this.apicache.middleware(expiration))
+
+  app.get('/api/movies', function(req, res) {
+    app.requestsProcessed++
+
+    res.json(movies)
+  })
+
+  app.get('/api/writeandend', function(req, res) {
+    app.requestsProcessed++
+
+    res.write('a')
+    res.write('b')
+    res.write('c')
+
+    res.end()
+  })
+
+  app.get('/api/testcachegroup', function(req, res) {
+    app.requestsProcessed++
+    req.apicacheGroup = 'cachegroup'
+
+    res.json(movies)
+  })
+
+  app.get('/api/text', function(req, res) {
+    app.requestsProcessed++
+
+    res.send('plaintext')
+  })
+
+  app.get('/api/html', function(req, res) {
+    app.requestsProcessed++
+
+    res.send('<html>')
+  })
+
+  app.get('/api/missing', function(req, res) {
+    app.requestsProcessed++
+
+    res.status(404).json({ success: false, message: 'Resource not found' })
+  })
+
+  app.get('/api/movies/:index', function(req, res) {
+    app.requestsProcessed++
+
+    res.json(movies[index])
+  })
+
+  app.apicache = apicache
+  app.requestsProcessed = 0
+
+  return app
+}
+
+module.exports = function(expiration, config) { return new MockAPI(expiration, config) }


### PR DESCRIPTION
So I've changed a few things, I've added `fake-redis` as a `devDependency` so that there's no need to have a running Redis instance. I've also added a mock Restify API and a test case that captures the bug. Rather than increase the size of this PR I will raise a separate on that makes all the tests against both Express and Restify (assuming you want to go down this route that is).