### PR TITLE
Fix caching of Buffer chunks

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -107,6 +107,12 @@ function ApiCache() {
     if (content) {
       if (typeof(content) == 'string') {
         res._apicache.content = (res._apicache.content || '') + content;
+      } else if (Buffer.isBuffer(content)) {
+        var oldContent = res._apicache.content
+        if (!oldContent) {
+          oldContent = Buffer.alloc(0);
+        }
+        res._apicache.content = Buffer.concat([oldContent, content], oldContent.length + content.length);
       } else {
         res._apicache.content = content
         // res._apicache.cacheable = false;

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -110,7 +110,7 @@ function ApiCache() {
       } else if (Buffer.isBuffer(content)) {
         var oldContent = res._apicache.content
         if (!oldContent) {
-          oldContent = Buffer.alloc(0);
+          oldContent = !Buffer.alloc ? new Buffer(0) : Buffer.alloc(0);
         }
         res._apicache.content = Buffer.concat([oldContent, content], oldContent.length + content.length);
       } else {

--- a/test/api/lib/routes.js
+++ b/test/api/lib/routes.js
@@ -22,9 +22,16 @@ module.exports = function(app) {
   app.get('/api/writebufferandend', function(req, res) {
     app.requestsProcessed++
 
-    res.write(Buffer.from('a'))
-    res.write(Buffer.from('b'))
-    res.write(Buffer.from('c'))
+
+    if (process.versions.node.indexOf('4') === 0) {
+      res.write(new Buffer([0x61]))
+      res.write(new Buffer([0x62]))
+      res.write(new Buffer([0x63]))
+    } else {
+      res.write(Buffer.from('a'))
+      res.write(Buffer.from('b'))
+      res.write(Buffer.from('c'))
+    }
 
     res.end()
   })

--- a/test/api/lib/routes.js
+++ b/test/api/lib/routes.js
@@ -19,6 +19,16 @@ module.exports = function(app) {
     res.end()
   })
 
+  app.get('/api/writebufferandend', function(req, res) {
+    app.requestsProcessed++
+
+    res.write(Buffer.from('a'))
+    res.write(Buffer.from('b'))
+    res.write(Buffer.from('c'))
+
+    res.end()
+  })
+
   app.get('/api/testcachegroup', function(req, res) {
     app.requestsProcessed++
     req.apicacheGroup = 'cachegroup'

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -240,6 +240,21 @@ describe('.middleware {MIDDLEWARE}', function() {
           })
       })
 
+      it('returns cached response from write Buffer+end', function() {
+        var app = mockAPI.create('10 seconds')
+
+        return request(app)
+          .get('/api/writebufferandend')
+          .expect(200, 'abc')
+          .then(assertNumRequestsProcessed(app, 1))
+          .then(function() {
+            return request(app)
+              .get('/api/writebufferandend')
+              .expect(200, 'abc')
+              .then(assertNumRequestsProcessed(app, 1))
+          })
+      })
+
       it('embeds store type and apicache version in cached responses', function() {
         var app = mockAPI.create('10 seconds')
 


### PR DESCRIPTION
This pull request is related to #72. It fixes the `accumulateContent` function to handle Buffer chunks correctly.
Test is included.