### PR TITLE
Cached headers dropped in node > v7.7.x due to api changes.

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -163,8 +163,8 @@ function ApiCache() {
 
 
   function sendCachedResponse(response, cacheObject) {
-    response._headers = response._headers || {}
-    Object.assign(response._headers, cacheObject.headers || {}, {
+    var headers = (typeof response.getHeaders === 'function') ? response.getHeaders() : response._headers;
+    Object.assign(headers, cacheObject.headers || {}, {
       'apicache-store': globalOptions.redisClient ? 'redis' : 'memory',
       'apicache-version': pkg.version
     })
@@ -175,7 +175,7 @@ function ApiCache() {
       data = new Buffer(data.data)
     }
 
-    response.writeHead(cacheObject.status || 200, response._headers)
+    response.writeHead(cacheObject.status || 200, headers)
 
     return response.end(data, cacheObject.encoding)
   }


### PR DESCRIPTION
Related to #60

Node 7.7 introduced some changes to the way http ServerResponse.headers can be manipulated (response._headers appears to have become readonly), so looks like we now have to use the new {set,get,has}Header methods:
https://nodejs.org/api/http.html#http_class_http_serverresponse