### PR TITLE
Add an option to disable caching of the response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ let cache5min = cache('5 min') // continue to use normally
   enabled:          true|false,     // if false, turns off caching globally (useful on dev)
   redisClient:      client,         // if provided, uses the [node-redis](https://github.com/NodeRedis/node_redis) client instead of [memory-cache](https://github.com/ptarjan/node-cache)
   appendKey:        [],             // if you want the key (which is the URL) to be appended by something in the req object, put req properties here that point to what you want appended. I.E. req.session.id would be ['session', 'id']
-  cacheHeaders:     true,           // if false, turns off caching of the response headers
+  headerBlacklist:  [],             // list of headers that should never be cached
   statusCodes: {
     exclude:        [],             // list status codes to specifically exclude (e.g. [404, 403] cache all responses unless they had a 404 or 403 status)
     include:        [],             // list status codes to require (e.g. [200] caches ONLY responses with a success/200 code)

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ let cache5min = cache('5 min') // continue to use normally
   enabled:          true|false,     // if false, turns off caching globally (useful on dev)
   redisClient:      client,         // if provided, uses the [node-redis](https://github.com/NodeRedis/node_redis) client instead of [memory-cache](https://github.com/ptarjan/node-cache)
   appendKey:        [],             // if you want the key (which is the URL) to be appended by something in the req object, put req properties here that point to what you want appended. I.E. req.session.id would be ['session', 'id']
+  cacheHeaders:     true,           // if false, turns off caching of the response headers
   statusCodes: {
     exclude:        [],             // list status codes to specifically exclude (e.g. [404, 403] cache all responses unless they had a 404 or 403 status)
     include:        [],             // list status codes to require (e.g. [200] caches ONLY responses with a success/200 code)

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -37,7 +37,7 @@ function ApiCache() {
     appendKey:          [],
     jsonp:              false,
     redisClient:        false,
-    cacheHeaders:       true,
+    headerBlacklist:    [],
     statusCodes: {
       include: [],
       exclude: [],
@@ -88,10 +88,19 @@ function ApiCache() {
     index.all.unshift(key)
   }
 
+  function filterBlacklistedHeaders(headers) {
+    return Object.keys(headers).filter(function (key) {
+      return !globalOptions.headerBlacklist.includes(key)
+    }).reduce(function (acc, header) {
+        acc[header] = headers[header];
+        return acc;
+    }, {});
+  }
+
   function createCacheObject(status, headers, data, encoding) {
     return {
       status: status,
-      headers: Object.assign({}, globalOptions.cacheHeaders ? headers : {}),
+      headers: filterBlacklistedHeaders(headers),
       data: data,
       encoding: encoding
     }
@@ -185,8 +194,8 @@ function ApiCache() {
 
   function sendCachedResponse(response, cacheObject) {
     var headers = (typeof response.getHeaders === 'function') ? response.getHeaders() : response._headers;
-    var cachedHeaders = globalOptions.cacheHeaders ? cacheObject.headers : {};
-    Object.assign(headers, cachedHeaders || {}, {
+
+    Object.assign(headers, filterBlacklistedHeaders(cacheObject.headers) || {}, {
       'apicache-store': globalOptions.redisClient ? 'redis' : 'memory',
       'apicache-version': pkg.version
     })

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -37,6 +37,7 @@ function ApiCache() {
     appendKey:          [],
     jsonp:              false,
     redisClient:        false,
+    cacheHeaders:       true,
     statusCodes: {
       include: [],
       exclude: [],
@@ -90,7 +91,7 @@ function ApiCache() {
   function createCacheObject(status, headers, data, encoding) {
     return {
       status: status,
-      headers: Object.assign({}, headers),
+      headers: Object.assign({}, globalOptions.cacheHeaders ? headers : {}),
       data: data,
       encoding: encoding
     }
@@ -184,7 +185,8 @@ function ApiCache() {
 
   function sendCachedResponse(response, cacheObject) {
     var headers = (typeof response.getHeaders === 'function') ? response.getHeaders() : response._headers;
-    Object.assign(headers, cacheObject.headers || {}, {
+    var cachedHeaders = globalOptions.cacheHeaders ? cacheObject.headers : {};
+    Object.assign(headers, cachedHeaders || {}, {
       'apicache-store': globalOptions.redisClient ? 'redis' : 'memory',
       'apicache-version': pkg.version
     })

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -195,7 +195,7 @@ function ApiCache() {
   function sendCachedResponse(response, cacheObject) {
     var headers = (typeof response.getHeaders === 'function') ? response.getHeaders() : response._headers;
 
-    Object.assign(headers, filterBlacklistedHeaders(cacheObject.headers) || {}, {
+    Object.assign(headers, filterBlacklistedHeaders(cacheObject.headers || {}), {
       'apicache-store': globalOptions.redisClient ? 'redis' : 'memory',
       'apicache-version': pkg.version
     })

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -90,7 +90,7 @@ function ApiCache() {
 
   function filterBlacklistedHeaders(headers) {
     return Object.keys(headers).filter(function (key) {
-      return !globalOptions.headerBlacklist.includes(key)
+      return globalOptions.headerBlacklist.indexOf(key) === -1;
     }).reduce(function (acc, header) {
         acc[header] = headers[header];
         return acc;

--- a/test/api/lib/routes.js
+++ b/test/api/lib/routes.js
@@ -43,6 +43,14 @@ module.exports = function(app) {
     res.end()
   })
 
+  app.get('/api/testheaderblacklist', function(req, res) {
+    app.requestsProcessed++
+    res.set('x-blacklisted', app.requestsProcessed)
+    res.set('x-notblacklisted', app.requestsProcessed)
+
+    res.json(movies)
+  })
+
   app.get('/api/testcachegroup', function(req, res) {
     app.requestsProcessed++
     req.apicacheGroup = 'cachegroup'

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -160,6 +160,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'test' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {}
@@ -171,6 +172,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'test' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {}
@@ -205,6 +207,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'bar' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: ['400'] },
         events: { expire: undefined },
         headers: {
@@ -218,6 +221,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: ['200'] },
         events: { expire: undefined },
         headers: {}
@@ -248,6 +252,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: ['400'] },
         events: { expire: undefined },
         headers: {}
@@ -259,6 +264,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: ['200'] },
         events: { expire: undefined },
         headers: {}
@@ -298,6 +304,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {
@@ -311,6 +318,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
+        cacheHeaders: true,
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {}

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -160,7 +160,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'test' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {}
@@ -172,7 +172,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'test' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {}
@@ -207,7 +207,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'bar' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: ['400'] },
         events: { expire: undefined },
         headers: {
@@ -221,7 +221,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: ['200'] },
         events: { expire: undefined },
         headers: {}
@@ -252,7 +252,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: ['400'] },
         events: { expire: undefined },
         headers: {}
@@ -264,7 +264,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: ['200'] },
         events: { expire: undefined },
         headers: {}
@@ -304,7 +304,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {
@@ -318,7 +318,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         appendKey: [ 'foo' ],
         jsonp: false,
         redisClient: false,
-        cacheHeaders: true,
+        headerBlacklist: [],
         statusCodes: { include: [], exclude: [] },
         events: { expire: undefined },
         headers: {}
@@ -370,7 +370,7 @@ describe('.middleware {MIDDLEWARE}', function() {
           })
       })
 
-       it('skips cache when using header "x-apicache-force-fetch (legacy)"', function() {
+      it('skips cache when using header "x-apicache-force-fetch (legacy)"', function() {
         var app = mockAPI.create('10 seconds')
 
         return request(app)
@@ -388,6 +388,25 @@ describe('.middleware {MIDDLEWARE}', function() {
                 expect(res.headers['apicache-store']).to.be.undefined
                 expect(res.headers['apicache-version']).to.be.undefined
                 expect(app.requestsProcessed).to.equal(2)
+              })
+          })
+      })
+
+      it('does not cache header in headerBlacklist', function() {
+        var app = mockAPI.create('10 seconds', {headerBlacklist: ['x-blacklisted']})
+
+        return request(app)
+          .get('/api/testheaderblacklist')
+          .expect(200, movies)
+          .then(function(res) {
+            expect(res.headers['x-blacklisted']).to.equal(res.headers['x-notblacklisted'])
+            return request(app)
+              .get('/api/testheaderblacklist')
+              .set('Accept', 'application/json')
+              .expect('Content-Type', /json/)
+              .expect(200, movies)
+              .then(function(res2) {
+                expect(res2.headers['x-blacklisted']).to.not.equal(res2.headers['x-notblacklisted'])
               })
           })
       })


### PR DESCRIPTION
I have an API whose response body content is very expensive and slow to generate. This content is guarded by session management middleware which will occasionally set cookies even on the cached responses. The current behaviour of apicache is to cache the set-cookie header (along with all the other headers) which breaks the session management middleware.

This PR adds the option to disable caching of the response headers to mitigate this issue for this use-case.