### PR TITLE
Prevent browser caching on requests that are configured to not get cached.

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -148,17 +148,9 @@ function ApiCache() {
     res._apicache = {
       write: res.write,
       end: res.end,
+      send: res.send,
       cacheable: true,
       content: undefined
-    }
-
-    // add cache control headers
-    if (!globalOptions.headers['cache-control']) {
-      if(shouldCacheResponse(res)) {
-        res.header('cache-control', 'max-age=' + (duration / 1000).toFixed(0));
-      } else {
-        res.header('cache-control', 'no-cache, no-store, must-revalidate');
-      }
     }
 
     // append header overwrites if applicable
@@ -170,6 +162,19 @@ function ApiCache() {
     res.write = function(content) {
       accumulateContent(res, content);
       return res._apicache.write.apply(this, arguments);
+    }
+
+    res.send = function() {
+      // add cache control headers
+      if (!globalOptions.headers['cache-control']) {
+        if(shouldCacheResponse(res)) {
+          res.header('cache-control', 'max-age=' + (duration / 1000).toFixed(0));
+        } else {
+          res.header('cache-control', 'no-cache, no-store, must-revalidate');
+        }
+      }
+
+      return res._apicache.send.apply(this, arguments);
     }
 
     // patch res.end

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -154,7 +154,11 @@ function ApiCache() {
 
     // add cache control headers
     if (!globalOptions.headers['cache-control']) {
-      res.header('cache-control', 'max-age=' + (duration / 1000).toFixed(0))
+      if(shouldCacheResponse(res)) {
+        res.header('cache-control', 'max-age=' + (duration / 1000).toFixed(0));
+      } else {
+        res.header('cache-control', 'no-cache, no-store, must-revalidate');
+      }
     }
 
     // append header overwrites if applicable

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -447,6 +447,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         return request(app)
           .get('/api/writeandend')
           .expect(200, 'abc')
+          .expect('Cache-Control', 'max-age=10')
           .then(assertNumRequestsProcessed(app, 1))
           .then(function() {
             return request(app)
@@ -462,6 +463,7 @@ describe('.middleware {MIDDLEWARE}', function() {
         return request(app)
           .get('/api/writebufferandend')
           .expect(200, 'abc')
+          .expect('Cache-Control', 'max-age=10')
           .then(assertNumRequestsProcessed(app, 1))
           .then(function() {
             return request(app)

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -579,7 +579,8 @@ describe('.middleware {MIDDLEWARE}', function() {
         return request(app)
           .get('/api/missing')
           .expect(404)
-          .then(function() {
+          .then(function(res) {
+            expect(res.headers['cache-control', 'no-cache, no-store, must-revalidate'])
             expect(app.apicache.getIndex().all.length).to.equal(0)
           })
       })
@@ -592,7 +593,8 @@ describe('.middleware {MIDDLEWARE}', function() {
         return request(app)
           .get('/api/missing')
           .expect(404)
-          .then(function() {
+          .then(function(res) {
+            expect(res.headers['cache-control', 'no-cache, no-store, must-revalidate'])
             expect(app.apicache.getIndex().all.length).to.equal(0)
           })
       })

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -580,7 +580,7 @@ describe('.middleware {MIDDLEWARE}', function() {
           .get('/api/missing')
           .expect(404)
           .then(function(res) {
-            expect(res.headers['cache-control', 'no-cache, no-store, must-revalidate'])
+            expect(res.headers['cache-control']).to.equal('no-cache, no-store, must-revalidate')
             expect(app.apicache.getIndex().all.length).to.equal(0)
           })
       })
@@ -594,7 +594,7 @@ describe('.middleware {MIDDLEWARE}', function() {
           .get('/api/missing')
           .expect(404)
           .then(function(res) {
-            expect(res.headers['cache-control', 'no-cache, no-store, must-revalidate'])
+            expect(res.headers['cache-control']).to.equal('no-cache, no-store, must-revalidate')
             expect(app.apicache.getIndex().all.length).to.equal(0)
           })
       })


### PR DESCRIPTION
I am having an issue with the browser caching error responses even though I have configured apicache to only cache on HTTP 200.

Right now a cache-control header to instruct the browser to cache the response is being sent even if apicache is configured to not cache the response.
