### PR TITLE
Release 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ let cache5min = cache('5 min') // continue to use normally
   defaultDuration:  '1 hour',       // should be either a number (in ms) or a string, defaults to 1 hour
   enabled:          true|false,     // if false, turns off caching globally (useful on dev)
   redisClient:      client,         // if provided, uses the [node-redis](https://github.com/NodeRedis/node_redis) client instead of [memory-cache](https://github.com/ptarjan/node-cache)
-  appendKey:        [],             // if you want the key (which is the URL) to be appended by something in the req object, put req properties here that point to what you want appended. I.E. req.session.id would be ['session', 'id']
+  appendKey:        fn(req, res),   // appendKey takes the req/res objects and returns a custom value to extend the cache key
   headerBlacklist:  [],             // list of headers that should never be cached
   statusCodes: {
     exclude:        [],             // list status codes to specifically exclude (e.g. [404, 403] cache all responses unless they had a 404 or 403 status)
@@ -155,6 +155,21 @@ let cache5min = cache('5 min') // continue to use normally
     // 'cache-control':  'no-cache' // example of header overwrite
   }
 }
+```
+
+## Custom Cache Keys
+
+Sometimes you need custom keys (e.g. save routes per-session, or per method).
+We've made it easy!
+
+**Note:** All req/res attributes used in the generation of the key must have been set
+previously (upstream).  The entire route logic block is skipped on future cache hits
+so it can't rely on those params.
+
+```js
+apicache.options({
+  appendKey: (req, res) => req.method + res.session.id
+})
 ```
 
 ## Cache Key Groups
@@ -268,3 +283,4 @@ Special thanks to all those that use this library and report issues, but especia
 - **v0.11.1** - correction to status code caching, and max-age headers are no longer sent when not cached.  middlewareToggle now works as intended with example of statusCode checking (checks during shouldCacheResponse cycle)
 - **v0.11.2** - dev-deps update, courtesy of @danielsogl
 - **v1.0.0** - stamping v0.11.2 into official production version, will now begin developing on branch v2.x (redesign)
+- **v1.1.0** - added the much-requested feature of a custom appendKey function (previously only took a path to a single request attribute).  Now takes (request, response) objects and returns some value to be appended to the cache key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apicache",
-  "version": "0.11.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apicache",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "scripts": {
     "lint": "eslint **/*.js",
     "pretest": "npm run lint",

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -386,7 +386,10 @@ function ApiCache() {
         key = url.parse(key).pathname
       }
 
-      if (opt.appendKey.length > 0) {
+      // add appendKey (either custom function or response path)
+      if (typeof opt.appendKey === 'function') {
+        key += '$$appendKey=' + opt.appendKey(req, res)
+      } else if (opt.appendKey.length > 0) {
         var appendKey = req
 
         for (var i = 0; i < opt.appendKey.length; i++) {

--- a/test/api/express-gzip.js
+++ b/test/api/express-gzip.js
@@ -9,6 +9,12 @@ function MockAPI(expiration, options, toggle) {
   // ENABLE COMPRESSION
   app.use(compression({ threshold: 1 }))
 
+  // EMBED UPSTREAM RESPONSE PARAM
+  app.use(function(req, res, next) {
+    res.id = 123
+    next()
+  })
+
   // ENABLE APICACHE
   app.use(apicache.middleware(expiration, toggle))
   app.apicache = apicache

--- a/test/api/express.js
+++ b/test/api/express.js
@@ -5,6 +5,12 @@ function MockAPI(expiration, options, toggle) {
   var apicache = require('../../src/apicache').newInstance(options)
   var app = express()
 
+  // EMBED UPSTREAM RESPONSE PARAM
+  app.use(function(req, res, next) {
+    res.id = 123
+    next()
+  })
+
   // ENABLE APICACHE
   app.use(apicache.middleware(expiration, toggle))
   app.apicache = apicache

--- a/test/api/restify-gzip.js
+++ b/test/api/restify-gzip.js
@@ -5,9 +5,15 @@ function MockAPI(expiration, options, toggle) {
   var apicache = require('../../src/apicache').newInstance(options)
   var app = restify.createServer()
 
-  var whichGzip = restify.gzipResponse && restify.gzipResponse() || restify.plugins.gzipResponse()
   // ENABLE COMPRESSION
+  var whichGzip = restify.gzipResponse && restify.gzipResponse() || restify.plugins.gzipResponse()
   app.use(whichGzip)
+
+  // EMBED UPSTREAM RESPONSE PARAM
+  app.use(function(req, res, next) {
+    res.id = 123
+    next()
+  })
 
   // ENABLE APICACHE
   app.use(apicache.middleware(expiration, toggle))

--- a/test/api/restify.js
+++ b/test/api/restify.js
@@ -5,6 +5,12 @@ function MockAPI(expiration, options, toggle) {
   var apicache = require('../../src/apicache').newInstance(options)
   var app = restify.createServer()
 
+  // EMBED UPSTREAM RESPONSE PARAM
+  app.use(function(req, res, next) {
+    res.id = 123
+    next()
+  })
+
   // ENABLE APICACHE
   app.use(apicache.middleware(expiration, toggle))
   app.apicache = apicache

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -451,8 +451,10 @@ describe('.middleware {MIDDLEWARE}', function() {
       })
 
       it('properly uses custom appendKey(req, res) function', function() {
-        let appendKey = (req, res) => req.method + res.id
-        var app = mockAPI.create('10 seconds', { appendKey })
+        var appendKey = function(req, res) {
+          return req.method + res.id
+        }
+        var app = mockAPI.create('10 seconds', { appendKey: appendKey })
 
         return request(app)
           .get('/api/movies')

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -445,10 +445,20 @@ describe('.middleware {MIDDLEWARE}', function() {
         return request(app)
           .get('/api/movies')
           .expect(200, movies)
-          .then(assertNumRequestsProcessed(app, 1))
           .then(function() {
-            expect(app.apicache.getIndex().all.length).to.equal(1)
             expect(app.apicache.getIndex().all[0]).to.equal('/api/movies$$appendKey=GET')
+          })
+      })
+
+      it('properly uses custom appendKey(req, res) function', function() {
+        let appendKey = (req, res) => req.method + res.id
+        var app = mockAPI.create('10 seconds', { appendKey })
+
+        return request(app)
+          .get('/api/movies')
+          .expect(200, movies)
+          .then(function() {
+            expect(app.apicache.getIndex().all[0]).to.equal('/api/movies$$appendKey=GET123')
           })
       })
 


### PR DESCRIPTION
Adds custom appendKey function support (in addition to previous array of request path syntax)

```js
apicache.options({
  appendKey: (req, res) => somevalue // return some value here, may use request/response object
})
```

