### PR TITLE
Fix cache clear callback expiration (#118)

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -53,6 +53,7 @@ function ApiCache() {
   var middlewareOptions = []
   var instance = this
   var index = null
+  var timers = {}
 
   instances.push(this)
   this.id = instances.length
@@ -127,7 +128,7 @@ function ApiCache() {
     }
 
     // add automatic cache clearing from duration, includes max limit on setTimeout
-    setTimeout(function() { instance.clear(key, true) }, Math.min(duration, 2147483647))
+    timers[key] = setTimeout(function() { instance.clear(key, true) }, Math.min(duration, 2147483647))
   }
 
   function accumulateContent(res, content) {
@@ -243,7 +244,8 @@ function ApiCache() {
 
       group.forEach(function(key) {
         debug('clearing cached entry for "' + key + '"')
-
+        clearTimeout(timers[key])
+        delete timers[key]
         if (!globalOptions.redisClient) {
           memCache.delete(key)
         } else {
@@ -259,7 +261,8 @@ function ApiCache() {
       delete index.groups[target]
     } else if (target) {
       debug('clearing ' + (isAutomatic ? 'expired' : 'cached') + ' entry for "' + target + '"')
-
+      clearTimeout(timers[target])
+      delete timers[target]
       // clear actual cached entry
       if (!redis) {
         memCache.delete(target)
@@ -291,6 +294,8 @@ function ApiCache() {
       } else {
         // clear redis keys one by one from internal index to prevent clearing non-apicache entries
         index.all.forEach(function(key) {
+          clearTimeout(timers[key])
+          delete timers[key]
           try {
             redis.del(key)
           } catch(err) {

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -677,6 +677,32 @@ describe('.middleware {MIDDLEWARE}', function() {
         }, 25)
       })
 
+      it('clearing cache cancels expiration callback', function(done) {
+        var app = mockAPI.create(20)
+
+        request(app)
+            .get('/api/movies')
+            .end(function(err, res) {
+              expect(app.apicache.getIndex().all.length).to.equal(1)
+              expect(app.apicache.clear('/api/movies').all.length).to.equal(0)
+            })
+
+        setTimeout(function() {
+          request(app)
+              .get('/api/movies')
+              .end(function(err, res) {
+                expect(app.apicache.getIndex().all.length).to.equal(1)
+                expect(app.apicache.getIndex().all).to.include('/api/movies')
+              })
+        }, 10)
+
+        setTimeout(function() {
+          expect(app.apicache.getIndex().all.length).to.equal(1)
+          expect(app.apicache.getIndex().all).to.include('/api/movies')
+          done()
+        }, 25)
+      })
+
       it('allows defaultDuration to be a parseable string (e.g. "1 week")', function(done) {
         var callbackResponse = undefined
         var cb = function(a,b) {


### PR DESCRIPTION
I have an issue which I described in #118 where clearing a cache target does not clear the expiration callback.  In short, if the same target is cleared and re-cached, the expiration callback from the original entry will still occur and clear the new entry. 

 I didn't see any contribution guidelines for this repository so I added a test case and made this pull request.