### PR TITLE
Add support for ioredis

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -414,7 +414,7 @@ function ApiCache() {
       if (redis) {
         try {
           redis.hgetall(key, function (err, obj) {
-            if (!err && obj) {
+            if (!err && obj && obj.response) {
               var elapsed = new Date() - req.apicacheTimer
               debug('sending cached (redis) version of', key, logDuration(elapsed))
 


### PR DESCRIPTION
I prefer using the [ioredis client](https://github.com/luin/ioredis) over node_redis since it supports promises out of the box.
In most cases ioredis is a simple drop in replacement since the API is mostly backwards compatible, but there's [one exception](https://github.com/luin/ioredis/wiki/Migrating-from-node_redis) that happens to break apicache when used with ioredis:
```
ioredis returns an empty object ({}) when hgetall a non-existed key while node_redis returns null.
```

This PR should fix the issue that caused `JSON.parse` to be invoked with `undefined`