### PR TITLE
RFC: add getDuration option to allow to override duration for each request

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -421,6 +421,12 @@ function ApiCache() {
         key += '$$appendKey=' + appendKey
       }
 
+
+      if (typeof opt.getDuration === 'function') {
+        strDuration = opt.getDuration(req, res)
+        duration = instance.getDuration(strDuration)
+      }
+
       // attempt cache hit
       var redis = opt.redisClient
       var cached = !redis ? memCache.getValue(key) : null

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -741,6 +741,33 @@ describe('.middleware {MIDDLEWARE}', function() {
           done()
         }, 25)
       })
+
+
+      it('allows to override duration with custom getDuration(req, res) function', function(done) {
+        var callbackResponse = undefined
+        var cb = function(a,b) {
+          callbackResponse = b
+        }
+
+        var app = mockAPI.create(null, { defaultDuration: '1000ms', events: { expire: cb }, getDuration: function(req, res) {
+          return '10ms';
+        }})
+
+        request(app)
+          .get('/api/movies')
+          .end(function(err, res) {
+            expect(app.apicache.getIndex().all.length).to.equal(1)
+            expect(app.apicache.getIndex().all).to.include('/api/movies')
+          })
+
+        setTimeout(function() {
+          expect(app.apicache.getIndex().all).to.have.length(0)
+          expect(callbackResponse).to.equal('/api/movies')
+          done()
+        }, 25)
+
+      })
+
     })
   })
 })


### PR DESCRIPTION
In our app, we'd like to have fine-grained control about cache duration depending on the current request.

Therefore, I added a `getDuration` hook that can be used to override the default duration.

If you'd be open to accept such a PR, I'll add the missing doumentation as well. :)
