### PR TITLE
Security issue : Removed apicache headers

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -222,10 +222,7 @@ function ApiCache() {
 
     var headers = (typeof response.getHeaders === 'function') ? response.getHeaders() : response._headers
 
-    Object.assign(headers, filterBlacklistedHeaders(cacheObject.headers || {}), {
-      'apicache-store': globalOptions.redisClient ? 'redis' : 'memory',
-      'apicache-version': pkg.version
-    })
+    Object.assign(headers, filterBlacklistedHeaders(cacheObject.headers || {}))
 
     // unstringify buffers
     var data = cacheObject.data


### PR DESCRIPTION
Removed apicache headers -> ( apicache-store and apicache-version) due to security issues. It was exposing store name and module name as a response in headers.