### PR TITLE
fix #148 - skip cached response when toggle function is falsy

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -215,9 +215,9 @@ function ApiCache() {
     next()
   }
 
-  function sendCachedResponse(request, response, cacheObject, toggle) {
+  function sendCachedResponse(request, response, cacheObject, toggle, next) {
     if (toggle && !toggle(request, response)) {
-      return false
+      return next();
     }
 
     var headers = (typeof response.getHeaders === 'function') ? response.getHeaders() : response._headers
@@ -430,7 +430,7 @@ function ApiCache() {
         var elapsed = new Date() - req.apicacheTimer
         debug('sending cached (memory-cache) version of', key, logDuration(elapsed))
 
-        return sendCachedResponse(req, res, cached, middlewareToggle)
+        return sendCachedResponse(req, res, cached, middlewareToggle, next)
       }
 
       // send if cache hit from redis
@@ -441,7 +441,7 @@ function ApiCache() {
               var elapsed = new Date() - req.apicacheTimer
               debug('sending cached (redis) version of', key, logDuration(elapsed))
 
-              return sendCachedResponse(req, res, JSON.parse(obj.response), middlewareToggle)
+              return sendCachedResponse(req, res, JSON.parse(obj.response), middlewareToggle, next)
             } else {
               return makeResponseCacheable(req, res, next, key, duration, strDuration, middlewareToggle)
             }

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -217,7 +217,7 @@ function ApiCache() {
 
   function sendCachedResponse(request, response, cacheObject, toggle, next) {
     if (toggle && !toggle(request, response)) {
-      return next();
+      return next()
     }
 
     var headers = (typeof response.getHeaders === 'function') ? response.getHeaders() : response._headers


### PR DESCRIPTION
Fix #148 

Return `next()` instead of `false` in `sendCachedResponse` in order to avoid a cached resource from blocking the response when toggle function is falsy.