### PR TITLE
Use native nodejs http features

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -165,16 +165,16 @@ function ApiCache() {
 
     // append header overwrites if applicable
     Object.keys(globalOptions.headers).forEach(function(name) {
-      res.header(name, globalOptions.headers[name])
+      res.setHeader(name, globalOptions.headers[name])
     })
 
     res.writeHead = function() {
       // add cache control headers
       if (!globalOptions.headers['cache-control']) {
         if(shouldCacheResponse(req, res, toggle)) {
-          res.header('cache-control', 'max-age=' + (duration / 1000).toFixed(0))
+          res.setHeader('cache-control', 'max-age=' + (duration / 1000).toFixed(0))
         } else {
-          res.header('cache-control', 'no-cache, no-store, must-revalidate')
+          res.setHeader('cache-control', 'no-cache, no-store, must-revalidate')
         }
       }
 

--- a/test/api/lib/routes.js
+++ b/test/api/lib/routes.js
@@ -19,7 +19,7 @@ module.exports = function(app) {
   app.get('/api/writeandend', function(req, res) {
     app.requestsProcessed++
 
-    res.header('Content-Type', 'text/plain')
+    res.setHeader('Content-Type', 'text/plain')
     res.write('a')
     res.write('b')
     res.write('c')
@@ -31,7 +31,7 @@ module.exports = function(app) {
     app.requestsProcessed++
 
 
-    res.header('Content-Type', 'text/plain')
+    res.setHeader('Content-Type', 'text/plain')
     if (process.versions.node.indexOf('4') === 0) {
       res.write(new Buffer([0x61]))
       res.write(new Buffer([0x62]))
@@ -62,14 +62,14 @@ module.exports = function(app) {
 
   app.get('/api/text', function(req, res) {
     app.requestsProcessed++
-    res.header('Content-Type', 'text/plain')
+    res.setHeader('Content-Type', 'text/plain')
 
     res.send('plaintext')
   })
 
   app.get('/api/html', function(req, res) {
     app.requestsProcessed++
-    res.header('Content-Type', 'text/html')
+    res.setHeader('Content-Type', 'text/html')
 
     res.send('<html>')
   })


### PR DESCRIPTION
This patch replaces express-specific calls to `res.header()` with native nodejs http API calls to [`res.setHeader()`](https://nodejs.org/api/http.html#http_response_setheader_name_value).

This was primarily done for compatibility with [Polka](https://github.com/lukeed/polka).