### PR TITLE
overwrite cached response headers with global options headers fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_STORE
 *.rdb
 .nyc_output
+.idea

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -226,7 +226,7 @@ function ApiCache() {
     Object.assign(headers, filterBlacklistedHeaders(cacheObject.headers || {}), {
       // set properly-decremented max-age header.  This ensures that max-age is in sync with the cache expiration.
       'cache-control': 'max-age=' + ((duration/1000 - (new Date().getTime()/1000 - cacheObject.timestamp))).toFixed(0)
-    })
+    }, globalOptions.headers)
 
     // only embed apicache headers when not in production environment
     if (process.env.NODE_ENV !== 'production') {

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -619,6 +619,7 @@ describe('.middleware {MIDDLEWARE}', function() {
               .expect('apicache-store', 'memory')
               .expect('apicache-version', pkg.version)
               .expect(200, movies)
+              .expect('Cache-Control', 'no-cache')
               .then(assertNumRequestsProcessed(app, 1))
           })
       })


### PR DESCRIPTION
Hi,
I start to use your lib in my project that is working very well :).
But I have found a strange behaviour about headers. 
In global and local options it's possible to overwrite headers: this works when request is not in cache, but no when request is cached.

I found a patch to use overwrite option headers in `sendCachedResponse`.