### PR TITLE
Fix wrongly used 'min' instead of 'minute'

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ let cache = apicache.options({
   },
 }).middleware
 
-let cache5min = cache('5 min') // continue to use normally
+let cache5min = cache('5 minute') // continue to use normally
 ```
 
 ## API


### PR DESCRIPTION
'5 min' does not work, it should be '5 minutes' or '5 minute'