### PR TITLE
IORedis Support for Connection check

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -131,8 +131,10 @@ function ApiCache() {
   function cacheResponse(key, value, duration) {
     var redis = globalOptions.redisClient
     var expireCallback = globalOptions.events.expire
-
-    if (redis && redis.connected) {
+    // Check if redis client is availeble and
+    // Also checks if redis.connected in case of node_redis and redis.status for ioredis
+    var isRedisAndConnected = redis ? redis.connected || redis.status === 'ready' : false
+    if (isRedisAndConnected) {
       try {
         redis.hset(key, 'response', JSON.stringify(value))
         redis.hset(key, 'duration', duration)


### PR DESCRIPTION
In the case of IORedis package which doesn't support the property called `connected`, In this change, I have added support to check for node_redis `connected `property OR ioredis `status` property whichever is present for further execution.

Please link this PR to Issue #204 