### PR TITLE
Allow requests to force cache to revalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ routes to be cached from your public client, but NOT cached when from the admin 
 is achieved by sending a `"x-apicache-bypass": true` header along with the requst from the admin.
 The presence of this header flag will bypass the cache, ensuring you aren't looking at stale data.
 
+Additionally, you may want to bypass loading stale content for a request while still updating the cache with fresh content. To achieve this, include a `"x-apicache-bypass": true` header with the request.
+
 ## Contributors
 
 Special thanks to all those that use this library and report issues, but especially to the following active users that have helped add to the core functionality!

--- a/src/apicache.js
+++ b/src/apicache.js
@@ -639,9 +639,11 @@ function ApiCache() {
       // attempt cache hit
       var redis = opt.redisClient
       var cached = !redis ? memCache.getValue(key) : null
+      // skip cache load when x-apicache-revalidate is present
+      var revalidate = req.headers['x-apicache-revalidate']
 
       // send if cache hit from memory-cache
-      if (cached) {
+      if (!revalidate && cached) {
         var elapsed = new Date() - req.apicacheTimer
         debug('sending cached (memory-cache) version of', key, logDuration(elapsed))
 
@@ -650,7 +652,7 @@ function ApiCache() {
       }
 
       // send if cache hit from redis
-      if (redis && redis.connected) {
+      if (!revalidate && redis && redis.connected) {
         try {
           redis.hgetall(key, function(err, obj) {
             if (!err && obj && obj.response) {

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -549,6 +549,31 @@ describe('.middleware {MIDDLEWARE}', function() {
           })
       })
 
+      it('revalidates cache when using header "x-apicache-revalidate"', function(done) {
+        var app = mockAPI.create('10 seconds')
+
+        request(app)
+          .get('/api/movies')
+          .expect(200, movies)
+          .expect('Cache-Control', 'max-age=10')
+          .then(assertNumRequestsProcessed(app, 1))
+          .then(function() {
+            setTimeout(function() {
+              return request(app)
+                .get('/api/movies')
+                .set('x-apicache-revalidate', true)
+                .expect(200, movies)
+                .expect('Cache-Control', 'max-age=10')
+                .then(function(res) {
+                  expect(res.headers['apicache-store']).to.be.undefined
+                  expect(res.headers['apicache-version']).to.be.undefined
+                  expect(app.requestsProcessed).to.equal(2)
+                  done()
+                })
+            }, 500)
+          })
+      })
+
       it('does not cache header in headerBlacklist', function() {
         var app = mockAPI.create('10 seconds', { headerBlacklist: ['x-blacklisted'] })
 


### PR DESCRIPTION
This PR provides a mechanism for "revalidating" cache contents on a per-request basis. When a request contains the `x-apicache-revalidate` header, we skip loading from the cache (similar to a cache "bypass") but still make the response cacheable in order to update the cache store with fresh content.

I've found this to be useful in cases that would otherwise require manually clearing the cache before sending a new request in order to allow fresh content to be stored. In particular, I am implementing a "stale-while-revalidate" caching strategy in my application which serves stale content while revalidating in the background when the cached response is close to expiry, so that subsequent requests will receive more up-to-date content without having to incur the full processing overhead before sending a response to the client.

_Note: I realized after-the-fact that this essentially duplicates the functionality from https://github.com/kwhitley/apicache/pull/220, which restored the original behavior for `x-apicache-force-fetch` which was regressed in https://github.com/kwhitley/apicache/pull/65. I personally find `revalidate` to be a more explicit description for the command (and less likely to be confused with `bypass`), but would be just as happy to see https://github.com/kwhitley/apicache/pull/220 merged in to restore this feature._